### PR TITLE
Fix bpf deadlock, which might occur when using DHCP

### DIFF
--- a/tuntap/src/tap/tap.cc
+++ b/tuntap/src/tap/tap.cc
@@ -180,6 +180,8 @@ tap_interface::initialize_interface()
 	/* we must call bpfattach(). Otherwise we deadlock BPF while unloading. Seems to be a bug in
 	 * the kernel, see bpfdetach() in net/bpf.c, it will return without releasing the lock if
 	 * the interface wasn't attached. I wonder what they were smoking while writing it ;-)
+	 * This has been fixed in latest kernels, but we keep it for older kernels.
+	 * Furthermore the call is needed e.g. in order that 'ipconfig set tapN DHCP' works.
 	 */
 	bpfattach(ifp, DLT_EN10MB, ifnet_hdrlen(ifp));
 


### PR DESCRIPTION
It seems like it's possible that during the processing of bpf_callback
sometimes set_bpf_tap is called which then deadlocks BPF
in the kernel.

This manifests in different problems on the network stack and OSX
can't even shutdown anymore because it can't unload the KEXT.

set_bpf_tap is deprecated so we could get rid of it, but I don't know
since what kernel version the new implementation is available.